### PR TITLE
Fix build with Java 11 by migrating to Java 8 Base64 encoder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: objective-c
 
 before_script:
-    - curl -o ant.tar.gz https://www.apache.org/dist/ant/binaries/apache-ant-1.10.1-bin.tar.gz
+    - curl -o ant.tar.gz https://www.apache.org/dist/ant/binaries/apache-ant-1.10.6-bin.tar.gz
     - tar xf ant.tar.gz
 
 script:
-    - PATH="$PATH:$PWD/apache-ant-1.10.1/bin" ./build_osx.bash
+    - PATH="$PATH:$PWD/apache-ant-1.10.6/bin" ./build_osx.bash
     - ls ./CRONoMeter.app

--- a/src/ca/spaz/cron/ExportWizard.java
+++ b/src/ca/spaz/cron/ExportWizard.java
@@ -5,6 +5,7 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.io.*;
 import java.net.*;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.List;
 
@@ -17,7 +18,6 @@ import javax.xml.parsers.DocumentBuilderFactory;
 
 import org.w3c.dom.*;
 
-import sun.misc.BASE64Encoder;
 import ca.spaz.cron.datasource.Datasources;
 import ca.spaz.cron.datasource.FoodProxy;
 import ca.spaz.cron.metrics.Metric;
@@ -115,7 +115,7 @@ public class ExportWizard extends JFrame {
 
     private String encodeCredentials() {
         try {
-            return new BASE64Encoder().encode((username.getText() + '\n' + new String(password.getPassword())).getBytes("UTF-8"));
+            return Base64.getEncoder().encodeToString((username.getText() + '\n' + new String(password.getPassword())).getBytes(StandardCharsets.UTF_8.toString()));
         } catch (UnsupportedEncodingException e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
The sun API is deprecated and this resulted in an error
during the execution of the ant build.