### PR TITLE
Fix Travis CI build by pointing to latest ant version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: objective-c
 
 before_script:
-    - curl -o ant.tar.gz https://www.apache.org/dist/ant/binaries/apache-ant-1.10.1-bin.tar.gz
+    - curl -o ant.tar.gz https://www.apache.org/dist/ant/binaries/apache-ant-1.10.6-bin.tar.gz
     - tar xf ant.tar.gz
 
 script:
-    - PATH="$PATH:$PWD/apache-ant-1.10.1/bin" ./build_osx.bash
+    - PATH="$PATH:$PWD/apache-ant-1.10.6/bin" ./build_osx.bash
     - ls ./CRONoMeter.app


### PR DESCRIPTION
Travis script was trying to download an ant version
that isn't hosted anymore by the apache foundation.